### PR TITLE
Add "url" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ There are 4 attributes that you will need to set to configure how you use the co
 
 | Attribute                                | Description      |Default                      |
 |:-----------------------------------------|:-------------|:---------------------------------|
-| `['3scale']['config-source']`                | Where your Nginx configuration files will be taken from. Two options: "local" or "3scale". More on this the section “Applying your own 3scale configuration”.    | `'local'`
+| `['3scale']['config-source']`                | Where your Nginx configuration files will be taken from. Three options: "local", "url" or "3scale". More on this the section “Applying your own 3scale configuration”.    | `'local'`
 | `['3scale']['provider-key']`                 | The key that identifies you as a 3scale customer. It can be found in the "Account" menu of your 3scale admin portal. | `'REPLACE_WITH_3SCALE_PROVIDER_KEY'`
 | `['3scale']['admin-domain']`               | If your 3scale admin portal domain is "mycompany-admin.3scale.net", then the value of this attribute should be "mycompany". | `'REPLACE_WITH_3SCALE_ADMIN_URL_PART'`
 | `['3scale']['config-version']` | Version id. If not included, the current configuration from your 3scale account will be used.  If included, the value must be a timestamp of one deployment, formatted like in the following example: "2015-09-15-041532". See the "Rollback process" section for more information on this. | `nil`
-
+| `['3scale']['config-url']` | URL endpoint from where the configuration files are downloaded when `[3scale][config-source] = "url"`. The URL endpoint pointed here should host a zip bundle with the files. Example: "https://s3.amazonaws.com/my-bucket-name/bundle.zip"  | `nil`
 
 
 The default value for each of those attributes is defined [here](https://github.com/3scale/chef-3scale/blob/master/attributes/default.rb).
@@ -43,7 +43,7 @@ Include `chef-3scale` in your node's `run_list`:
 
 For the API gateway to be configured for your own API endpoints, you need to deploy it using your own set of Nginx configuration files. 
 
-There are two ways to apply your own configuration files to the cookbook:
+There are three ways to apply your own configuration files to the cookbook:
 
 ### Option 1: Local configuration files 
 
@@ -63,8 +63,18 @@ To use this option you will need to set the following attributes in your node or
 - **['3scale']['provider-key']**  = (see attributes section)  
 - **['3scale']['admin-domain']**  = (see attributes section)  
 
+### Option 3: Fetch configuration files from any URL endpoint
 
-In both cases, the Nginx configuration files will be copied to a subdirectory in the `/var/chef/cache/` and symlinked to the Nginx working directory (`/etc/nginx/`).
+With this option the cookbook will automatically fetch the Nginx configuration files from the URL endpoint specified in the `[3scale][config-ur]` attribute. That endpoint should host a zip bundle of the configuration files.
+  
+To use this option you will need to set the following attributes in your node or role description:  
+
+- **['3scale']['config-source']** = “url”   
+- **['3scale']['config-url']**    = (see attributes section)  
+  
+
+#### Note
+In all three deployment options the Nginx configuration files will be copied to a subdirectory in the `/var/chef/cache/` and symlinked to the Nginx working directory (`/etc/nginx/`).
 
 ## Rollback process
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,13 @@
 # Configuration files source. Possible values: 'local', '3scale'
 #   - local: files are located in the cookbook files/default/ directory
 #   - 3scale: files are directly downloaded from your 3scale account
+#   - url: files are directly downloaded by an url specified as an attribute
 default['3scale']['config-source'] = 'local'
+
+# URL used in the config-source = 'url' mode
+# from where the config files will be fetched
+# (only required if config-source == 'url')
+default['3scale']['config-url'] = nil
 
 # 3scale account information
 #   - provider_key: the key that identifies you as a 3scale user

--- a/libraries/default_helper.rb
+++ b/libraries/default_helper.rb
@@ -30,6 +30,15 @@ class Chef::Recipe::Helpers
     end
   end
 
+  def self.fetch_from_url(url, dest_dir)
+    response = HTTPClient.get(url, follows_redirect: true)
+    if response.status == 200
+      unzip(response.body, dest_dir)
+    else
+      raise 'Could not fetch files from 3scale'
+    end
+  end
+
   def self.fetch_3scale_config(admin_domain, provider_key, dest_dir)
     path = '/admin/api/nginx.zip'
     url = "https://#{admin_domain}-admin.3scale.net#{path}?provider_key=#{provider_key}"

--- a/libraries/default_helper.rb
+++ b/libraries/default_helper.rb
@@ -42,12 +42,7 @@ class Chef::Recipe::Helpers
   def self.fetch_3scale_config(admin_domain, provider_key, dest_dir)
     path = '/admin/api/nginx.zip'
     url = "https://#{admin_domain}-admin.3scale.net#{path}?provider_key=#{provider_key}"
-    response = HTTPClient.get(url, follows_redirect: true)
-    if response.status == 200
-      unzip(response.body, dest_dir)
-    else
-      raise 'Could not fetch files from 3scale'
-    end
+    fetch_from_url(url, dest_dir)
   end
 
   def self.link_files(from_dir, openresty_dir)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@3scale.net'
 license          'MIT'
 description      'Install and configures the 3scale API gateway'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.2.0'
 
 supports 'ubuntu'
 supports 'centos'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,6 +52,20 @@ if mode == '3scale'
     end
     action :run
   end
+elsif mode == 'url'
+  # create directory to store downloaded configuration
+  directory version_dir do
+    owner node['openresty']['user']
+    recursive true
+    action :create
+  end
+
+  ruby_block 'fetch configuration files from a URL' do
+    block do
+      Helpers.fetch_from_url(node['3scale']['config-url'], version_dir)
+    end
+    action :run
+  end
 elsif mode == 'local'
   # copy configuration files located at files/default/config
   remote_directory version_dir do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -84,6 +84,31 @@ describe 'chef-3scale::default' do
 end
 
 describe 'chef-3scale::default' do
+  context 'URL mode' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['network']['interfaces']['lo']['addresses'] = '127.0.0.1'
+        node.set['kernel']['release'] = '2.6.32-504'
+        node.set['3scale']['config-source']  = 'url'
+        node.set['3scale']['config-url'] = 'http://example.com/bundle.zip'
+      end.converge(described_recipe)
+    end
+
+    it 'creates output directory' do
+      expect(chef_run).to create_directory('/var/chef/cache/2015-09-17-121010')
+    end
+
+    it 'runs ruby_block to download files from a URL' do
+      expect(chef_run).to run_ruby_block('fetch configuration files from a URL')
+    end
+
+    it 'runs ruby_block to symlink config files' do
+      expect(chef_run).to run_ruby_block('symlink configuration files')
+    end
+  end
+end
+
+describe 'chef-3scale::default' do
   context 'rollback mode' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|


### PR DESCRIPTION
Allow configuration files to be retrieved from a URL that is passed as an attribute to the cookbook.
The file that is downloaded should be a zip bundle of all Nginx configuration files.