### PR TITLE
Compile time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 source 'https://rubygems.org'
 
 group :test do

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@3scale.net'
 license          'MIT'
 description      'Install and configures the 3scale API gateway'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.2.1'
 
 supports 'ubuntu'
 supports 'centos'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,10 +14,10 @@ include_recipe 'openresty::commons_script'
 include_recipe 'openresty::commons_build'
 
 chef_gem 'httpclient' do
-  compile_time true
+  compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
 end
 chef_gem 'rubyzip' do
-  compile_time true
+  compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
 end
 require 'httpclient'
 require 'zip'


### PR DESCRIPTION
Fix incompatibility with Chef versions lower than 12 due to `compile_time` method: https://www.chef.io/blog/2015/02/17/chef-12-1-0-chef_gem-resource-warnings/

