### PR TITLE
Remove node.rm

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,9 +85,6 @@ end
 ruby_block 'symlink configuration files' do
   block do
     Helpers.link_files(version_dir, node['openresty']['dir'])
-    # fix chef bug where attributes with a default
-    # value of 'nil' are always overriden
-    # node.rm('3scale')
   end
   action :run
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -87,7 +87,7 @@ ruby_block 'symlink configuration files' do
     Helpers.link_files(version_dir, node['openresty']['dir'])
     # fix chef bug where attributes with a default
     # value of 'nil' are always overriden
-    node.rm('3scale')
+    # node.rm('3scale')
   end
   action :run
 


### PR DESCRIPTION
`node.rm` is not compatible with Chef 11 but, moreover, after more testing it turns out it isn't really necessary.