### PR TITLE
Change rubyzip usage

### DIFF
--- a/libraries/default_helper.rb
+++ b/libraries/default_helper.rb
@@ -17,12 +17,10 @@ class Chef::Recipe::Helpers
   end
 
   def self.unzip(data, dest_dir)
-    io = StringIO.new(data)
-
-    ::Zip::InputStream.open(io) do |fzip|
-      while entry = fzip.get_next_entry
+    ::Zip::File.open_buffer(data) do |fzip|
+      fzip.each do |entry|
         next unless is_config?(entry.name)
-        content = fzip.read
+        content = fzip.read(entry)
         filename = out_filename(entry.name)
         path = File.join(dest_dir, filename)
         File.write(path, content)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@3scale.net'
 license          'MIT'
 description      'Install and configures the 3scale API gateway'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.2'
+version          '0.2.3'
 
 supports 'ubuntu'
 supports 'centos'


### PR DESCRIPTION
Use `Zip::File` instead of `Zip::InputStream`.

This fixes occasional issues caused by a bug in rubyzip, described here:
https://github.com/rubyzip/rubyzip#notice-about-zipinputstream