### PR TITLE
making compatible with chef -11 and ruby -1.8.7 

### DIFF
--- a/libraries/default_helper.rb
+++ b/libraries/default_helper.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: dj-chef-3scale
+# Cookbook Name:: chef-3scale
 # Recipe:: default
 #
 # Copyright (C) 2015 3scale Inc. (https://3scale.net)

--- a/libraries/default_helper.rb
+++ b/libraries/default_helper.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: chef-3scale
+# Cookbook Name:: dj-chef-3scale
 # Recipe:: default
 #
 # Copyright (C) 2015 3scale Inc. (https://3scale.net)
@@ -8,22 +8,18 @@
 #
 
 class Chef::Recipe::Helpers
-  def self.unzip(data, dest_dir)
-    ::Zip::File.open_buffer(data) do |fzip|
-      fzip.each do |entry|
-       path = File.join(dest_dir, entry.name)
-       FileUtils::mkdir_p(File.dirname(path))
-       fzip.extract(entry, path) unless File.exist?(path)
-      end
-    end
+  def self.unzip(zipfile, dest_dir)
+     Archive::Zip.extract(zipfile, dest_dir)
   end
 
   def self.fetch_from_url(url, dest_dir)
     response = HTTPClient.get(url, follows_redirect: true)
     if response.status == 200
-      unzip(response.body, dest_dir)
+      zip_path = File.join(dest_dir, "bundle.zip")
+      File.open(zip_path, 'w') { |file| file.write(response.body) }
+      unzip(zip_path, dest_dir)
     else
-      raise 'Could not fetch files from 3scale'
+      raise "Could not fetch files from URL: #{url}"
     end
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,11 +16,11 @@ include_recipe 'openresty::commons_build'
 chef_gem 'httpclient' do
   compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
 end
-chef_gem 'rubyzip' do
+chef_gem 'archive-zip' do
   compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
 end
 require 'httpclient'
-require 'zip'
+require 'archive/zip'
 require 'fileutils'
 
 time = Time.new.strftime("%Y-%m-%d-%H%M%S")


### PR DESCRIPTION
chef_gem 'archive/zip' do or chef_gem 'archive-zip' do . chef_gem 'archive/zip' do fails with ArgumentError: Illformed requirement [""]  plus when I gem install zrchive/zip, it can't find it. 

I do archive-zip and it gets to the url part but fails as it is not instantiated , so I change to require 'archive/zip'.That does the trick and the chef recipe works like a charm now! 
